### PR TITLE
to always match when using code alignment packages

### DIFF
--- a/grammars/ansible.cson
+++ b/grammars/ansible.cson
@@ -18,7 +18,7 @@ patterns: [
     captures:
       "2":
         name: "string.quoted.double.ansible"
-    match: "\\- (name\\:|include\\:) (.*)|(^(- |\\s*)\\w+\\:)"
+    match: "\\- (name\\:|include\\:) (.*)|(^(- |\\s*)\\w+\\ *:)"
     name: "keyword.other.ansible"
   }
   {


### PR DESCRIPTION
examples:

```
name   : "James"
age    : "24"
address: "123 York"
```
