### PR TITLE
Add Ansible (advanced) that support Jinja2 and Ansible conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # Ansible Syntax Highlighting Package
 
-This extension to enable syntax highlighting for Ansible in the Atom Editor.
-It's based on the [original Ansible Sublime-text package](https://github.com/clifford-github/sublime-ansible) with my own fixes.
+This extension add 2 grammars to enable syntax highlighting for Ansible in the Atom Editor.
+
+- `Ansible`: It's based on the [original Ansible Sublime-text package](https://github.com/clifford-github/sublime-ansible) with my own fixes.
+- `Ansible (advanced)` : It's based on YAML language of 2015 FichteFoll <fichtefoll2@googlemail.com> with modifications to support :
+    - Jinja language
+    - Jinja expressions for ansible conditions (`when`, `changed_when`, `failed_when`, `check_mode`)
+    - Some YAML block scalar
 
 
 ## Adding ansible yaml file detection
@@ -35,4 +40,3 @@ Manually defining custom file types.
         "yml"
       ]
 ```
-

--- a/grammars/Ansible (Advanced).cson
+++ b/grammars/Ansible (Advanced).cson
@@ -1,0 +1,813 @@
+name: "Ansible (advanced)"
+scopeName: "source.ansible-advanced"
+fileTypes: []
+uuid: "99ac36b1-d3e8-44f3-9933-3d36a95e87ff"
+patterns: [
+  {
+    include: "#comment"
+  }
+  {
+    include: "#property"
+  }
+  {
+    include: "#directive"
+  }
+  {
+    name: "entity.other.document.begin.ansible-advanced"
+    match: "^---"
+  }
+  {
+    name: "entity.other.document.end.ansible-advanced"
+    match: "^\\.{3}"
+  }
+  {
+    include: "#conditions"
+  }
+  {
+    include: "#node"
+  }
+]
+repository:
+  comment:
+    begin: "(?:(^[ \\t]*)|[ \\t]+)(?=#\\p{Print}*$)"
+    beginCaptures:
+      "1":
+        name: "punctuation.whitespace.comment.leading.ansible-advanced"
+    end: "(?!\\G)"
+    patterns: [
+      {
+        name: "comment.line.number-sign.ansible-advanced"
+        begin: "#"
+        beginCaptures:
+          "0":
+            name: "punctuation.definition.comment.ansible-advanced"
+        end: "\\n"
+      }
+    ]
+  property:
+    name: "meta.property.ansible-advanced"
+    begin: "(?=!|&)"
+    end: "(?!\\G)"
+    patterns: [
+      {
+        match: "\\G((&))([^\\s\\[\\]/{/},]+)(\\S+)?"
+        captures:
+          "1":
+            name: "keyword.control.property.anchor.ansible-advanced"
+          "2":
+            name: "punctuation.definition.anchor.ansible-advanced"
+          "3":
+            name: "entity.name.type.anchor.ansible-advanced"
+          "4":
+            name: "invalid.illegal.character.anchor.ansible-advanced"
+      }
+      {
+        name: "storage.type.tag-handle.ansible-advanced"
+        match: '''
+          (?x) \\G (?:
+              ! < (?: %\\p{XDigit}{2} | [0-9A-Za-z\\-#;/?:@&=+$,_.!~*'()\\[\\]] )+ >
+            | (?:!(?:[0-9A-Za-z\\-]*!)?) (?: %\\p{XDigit}{2} | [0-9A-Za-z\\-#;/?:@&=+$_.~*'()] )+
+            | !
+          ) (?=\\ |\\t|$)
+        '''
+      }
+      {
+        name: "invalid.illegal.tag-handle.ansible-advanced"
+        match: "\\S+"
+      }
+    ]
+  directive:
+    name: "meta.directive.ansible-advanced"
+    begin: "^%"
+    beginCaptures:
+      "0":
+        name: "punctuation.definition.directive.begin.ansible-advanced"
+    end: "(?=$|[ \\t]+($|#))"
+    patterns: [
+      {
+        match: "\\G(YAML)[ \\t]+(\\d+\\.\\d+)"
+        captures:
+          "1":
+            name: "keyword.other.directive.ansible-advanced.ansible-advanced"
+          "2":
+            name: "constant.numeric.ansible-advanced-version.ansible-advanced"
+      }
+      {
+        match: '''
+          (?x) \\G (TAG) (?:[ \\t]+
+              ((?:!(?:[0-9A-Za-z\\-]*!)?))
+              (?:[ \\t]+ (
+                    !              (?x: %\\p{XDigit}{2} | [0-9A-Za-z\\-#;/?:@&=+$,_.!~*'()\\[\\]] )*
+                  | (?![,!\\[\\]{}]) (?x: %\\p{XDigit}{2} | [0-9A-Za-z\\-#;/?:@&=+$,_.!~*'()\\[\\]] )+
+                  )
+              )?
+          )?
+        '''
+        captures:
+          "1":
+            name: "keyword.other.directive.tag.ansible-advanced"
+          "2":
+            name: "storage.type.tag-handle.ansible-advanced"
+          "3":
+            name: "support.type.tag-prefix.ansible-advanced"
+      }
+      {
+        match: "(?x) \\G (\\w+) (?:[ \\t]+ (\\w+) (?:[ \\t]+ (\\w+))? )?"
+        captures:
+          "1":
+            name: "support.other.directive.reserved.ansible-advanced"
+          "2":
+            name: "string.unquoted.directive-name.ansible-advanced"
+          "3":
+            name: "string.unquoted.directive-parameter.ansible-advanced"
+      }
+      {
+        name: "invalid.illegal.unrecognized.ansible-advanced"
+        match: "\\S+"
+      }
+    ]
+  node:
+    patterns: [
+      {
+        include: "#block-node"
+      }
+    ]
+  "block-node":
+    patterns: [
+      {
+        include: "#prototype"
+      }
+      {
+        include: "#block-scalar"
+      }
+      {
+        include: "#block-collection"
+      }
+      {
+        include: "#flow-scalar-plain-out"
+      }
+      {
+        include: "#flow-node"
+      }
+    ]
+  prototype:
+    patterns: [
+      {
+        include: "#comment"
+      }
+      {
+        include: "#property"
+      }
+    ]
+  "block-scalar":
+    begin: "(\\s*)(?:(?:-\\s+)?(\\S+):\\s+|-\\s+)(?:(\\|)|(>))([1-9])?([-+])?(.*\\n?)"
+    contentName: "string.unquoted.block.ansible-advanced"
+    beginCaptures:
+      "2":
+        name: "keyword.ansible-advanced"
+      "3":
+        name: "punctuation.definition.block.scalar.literal.ansible-advanced"
+      "4":
+        name: "punctuation.definition.block.scalar.folded.ansible-advanced"
+      "5":
+        name: "constant.numeric.indentation-indicator.ansible-advanced"
+      "6":
+        name: "support.other.chomping-indicator.ansible-advanced"
+      "7":
+        patterns: [
+          {
+            include: "#comment"
+          }
+          {
+            name: "invalid.illegal.expected-comment-or-newline.ansible-advanced"
+            match: ".+"
+          }
+        ]
+    patterns: [
+      {
+        include: "source.jinja"
+      }
+    ]
+    end: "^(?!\\1\\s+\\S|$)"
+  "block-collection":
+    patterns: [
+      {
+        include: "#block-sequence"
+      }
+      {
+        include: "#block-mapping"
+      }
+    ]
+  "block-sequence":
+    name: "punctuation.definition.block.sequence.item.ansible-advanced"
+    match: "(-)( |\\t|$)"
+  "block-mapping":
+    patterns: [
+      {
+        include: "#block-pair"
+      }
+    ]
+  "flow-scalar-plain-out":
+    patterns: [
+      {
+        include: "#flow-scalar-plain-out-implicit-type"
+      }
+      {
+        name: "string.unquoted.plain.out.ansible-advanced"
+        begin: '''
+          (?x)
+            (?=[^\\s[-?:,\\[\\]{}#&*!|>'"%@`]])
+          | [?:-] (?=\\S)
+        '''
+        end: '''
+          (?x)
+          (?=
+                \\s* $
+              | \\s+ \\#
+              | \\s* : (\\s|$)
+          )
+        '''
+        patterns: [
+          {
+            include: "#specials"
+          }
+        ]
+      }
+    ]
+  specials:
+    patterns: [
+      {
+        include: "source.jinja"
+      }
+      {
+        match: "([\\w-]+?)="
+        captures:
+          "1":
+            name: "entity.other.attribute-name.ansible-advanced-advence"
+      }
+    ]
+  conditions:
+    patterns: [
+      {
+        begin: "\\b((?:changed_|failed_)?when|check_mode)\\b\\s*:(?! [|>]|\\s*$)(\\s+[\"'])?"
+        end: "(?:[\"'])?$"
+        beginCaptures:
+          "1":
+            name: "keyword.other.special-method.ansible-advanced"
+        patterns: [
+          {
+            include: "source.jinja#expression"
+          }
+        ]
+      }
+      {
+        begin: "(\\s*)(?:(?:-\\s+)?((?:changed_|failed_)?when|check_mode):\\s+|-\\s+)(?:(\\|)|(>))([1-9])?([-+])?(.*\\n?)"
+        contentName: "string.unquoted.block.ansible-advanced"
+        beginCaptures:
+          "2":
+            name: "keyword.other.special-method.ansible-advanced"
+          "3":
+            name: "punctuation.definition.block.scalar.literal.ansible-advanced"
+          "4":
+            name: "punctuation.definition.block.scalar.folded.ansible-advanced"
+          "5":
+            name: "constant.numeric.indentation-indicator.ansible-advanced"
+          "6":
+            name: "support.other.chomping-indicator.ansible-advanced"
+          "7":
+            patterns: [
+              {
+                include: "#comment"
+              }
+              {
+                name: "invalid.illegal.expected-comment-or-newline.ansible-advanced"
+                match: ".+"
+              }
+            ]
+        patterns: [
+          {
+            include: "source.jinja#expression"
+          }
+        ]
+        end: "^(?!\\1\\s+\\S|$)"
+      }
+      {
+        begin: "^(\\s*)(?:(?:-\\s+)?((?:changed_|failed_)?when|check_mode)):$"
+        beginCaptures:
+          "2":
+            name: "keyword.other.special-method.ansible-advanced"
+        end: "^(?!\\1\\s+-\\s+\\S|$)"
+        patterns: [
+          {
+            begin: "(?:[\"'])(.*)(?=[\"']\\s*?$)"
+            beginCaptures:
+              "1":
+                patterns: [
+                  {
+                    include: "source.jinja#expression"
+                  }
+                ]
+            end: "$"
+          }
+          {
+            include: "source.jinja#expression"
+          }
+        ]
+      }
+    ]
+  "flow-node":
+    patterns: [
+      {
+        include: "#prototype"
+      }
+      {
+        include: "#flow-alias"
+      }
+      {
+        include: "#flow-collection"
+      }
+      {
+        include: "#flow-scalar"
+      }
+    ]
+  "flow-alias":
+    match: "((\\*))([^\\s\\[\\]/{/},]+)([^\\s\\]},]\\S*)?"
+    captures:
+      "1":
+        name: "keyword.control.flow.alias.ansible-advanced"
+      "2":
+        name: "punctuation.definition.alias.ansible-advanced"
+      "3":
+        name: "keyword.other.alias.ansible-advanced"
+      "4":
+        name: "invalid.illegal.character.anchor.ansible-advanced"
+  "flow-collection":
+    patterns: [
+      {
+        include: "#flow-sequence"
+      }
+      {
+        include: "#flow-mapping"
+      }
+    ]
+  "flow-sequence":
+    name: "meta.flow-sequence.ansible-advanced"
+    begin: "\\["
+    beginCaptures:
+      "0":
+        name: "punctuation.definition.sequence.begin.ansible-advanced"
+    end: "\\]"
+    endCaptures:
+      "0":
+        name: "punctuation.definition.sequence.end.ansible-advanced"
+    patterns: [
+      {
+        include: "#prototype"
+      }
+      {
+        name: "punctuation.separator.sequence.ansible-advanced"
+        match: ","
+      }
+      {
+        include: "#flow-pair"
+      }
+      {
+        include: "#flow-node"
+      }
+    ]
+  "block-pair":
+    patterns: [
+      {
+        name: "meta.block-mapping.ansible-advanced"
+        begin: "\\?"
+        beginCaptures:
+          "1":
+            name: "punctuation.definition.key-value.begin.ansible-advanced"
+        end: "(?=\\?)|^ *(:)|(:)"
+        endCaptures:
+          "1":
+            name: "punctuation.separator.key-value.mapping.ansible-advanced"
+          "2":
+            name: "invalid.illegal.expected-newline.ansible-advanced"
+        patterns: [
+          {
+            include: "#block-node"
+          }
+        ]
+      }
+      {
+        begin: '''
+          (?x)
+          (?=
+            (?x:
+                [^\\s[-?:,\\[\\]{}#>*!|&'"%@`]]
+              | [?:-] \\S
+            )
+            (
+                [^\\s:]
+              | : \\S
+              | \\s+ (?![#\\s])
+            )*
+            \\s*
+            :
+            (\\s|$)
+          )
+        '''
+        end: '''
+          (?x)
+          (?=
+              \\s* $
+            | \\s+ \\#
+            | \\s* : (\\s|$)
+          )
+        '''
+        patterns: [
+          {
+            include: "#flow-scalar-plain-out-implicit-type"
+          }
+          {
+            name: "string.unquoted.plain.out.ansible-advanced"
+            contentName: "keyword.other.ansible-advanced"
+            begin: '''
+              (?x)
+                [^\\s[-?:,\\[\\]{}#&*!|>'"%@`]]
+              | [?:-] (?=\\S)
+            '''
+            beginCaptures:
+              "0":
+                name: "keyword.other.ansible-advanced"
+            end: '''
+              (?x)
+              (?=
+                  \\s* $
+                | \\s+ \\#
+                | \\s* : (\\s|$)
+              )
+            '''
+          }
+        ]
+      }
+      {
+        name: "punctuation.separator.key-value.mapping.ansible-advanced"
+        match: ":(?=\\s|$)"
+      }
+    ]
+  "flow-mapping":
+    name: "meta.flow-mapping.ansible-advanced"
+    begin: "\\{"
+    beginCaptures:
+      "0":
+        name: "punctuation.definition.mapping.begin.ansible-advanced"
+    end: "\\}"
+    endCaptures:
+      "0":
+        name: "punctuation.definition.mapping.end.ansible-advanced"
+    patterns: [
+      {
+        include: "#prototype"
+      }
+      {
+        name: "punctuation.separator.mapping.ansible-advanced"
+        match: ","
+      }
+      {
+        include: "#flow-pair"
+      }
+    ]
+  "flow-pair":
+    patterns: [
+      {
+        name: "meta.flow-pair.explicit.ansible-advanced"
+        begin: "\\?"
+        beginCaptures:
+          "0":
+            name: "punctuation.definition.key-value.begin.ansible-advanced"
+        end: "(?=[},\\]])"
+        patterns: [
+          {
+            include: "#prototype"
+          }
+          {
+            include: "#flow-pair"
+          }
+          {
+            include: "#flow-node"
+          }
+          {
+            begin: ":(?=\\s|$|[\\[\\]{},])"
+            beginCaptures:
+              "0":
+                name: "punctuation.separator.key-value.mapping.ansible-advanced"
+            end: "(?=[},\\]])"
+            patterns: [
+              {
+                include: "#flow-value"
+              }
+            ]
+          }
+        ]
+      }
+      {
+        name: "meta.flow-pair.key.ansible-advanced"
+        begin: '''
+          (?x)
+          (?=
+            (?x:
+                  [^\\s[-?:,\\[\\]{}#&*!|>'"%@`]]
+                | [?:-] \\S
+            )
+            (
+                  [^\\s:]
+                | : \\S
+                | \\s+ (?![#\\s])
+            )*
+            \\s*
+            :
+            (\\s|$)
+          )
+        '''
+        end: '''
+          (?x)
+          (?=
+                \\s* $
+              | \\s+ \\#
+              | \\s* : (\\s|$)
+          )
+        '''
+        patterns: [
+          {
+            include: "#flow-scalar-plain-in-implicit-type"
+          }
+          {
+            name: "string.unquoted.plain.in.ansible-advanced"
+            contentName: "keyword.other.ansible-advanced"
+            begin: '''
+              (?x)
+                [^\\s[-?:,\\[\\]{}#&*!|>'"%@`]]
+              | [?:-] [^\\s[\\[\\]{},]]
+            '''
+            beginCaptures:
+              "0":
+                name: "keyword.other.ansible-advanced"
+            end: '''
+              (?x) (?=
+                  \\s* $
+                | \\s+ \\#
+                | \\s* : (\\s|$)
+                | \\s* : [\\[\\]{},]
+                | \\s* [\\[\\]{},]
+              )
+            '''
+          }
+        ]
+      }
+      {
+        include: "#flow-node"
+      }
+      {
+        name: "meta.flow-pair.ansible-advanced"
+        begin: ":(?=\\s|$|[\\[\\]{},])"
+        end: "(?=[},\\]])"
+        captures:
+          "0":
+            name: "punctuation.separator.key-value.mapping.ansible-advanced"
+        patterns: [
+          {
+            include: "#flow-value"
+          }
+        ]
+      }
+    ]
+  "flow-scalar":
+    patterns: [
+      {
+        include: "#flow-scalar-double-quoted"
+      }
+      {
+        include: "#flow-scalar-single-quoted"
+      }
+      {
+        include: "#flow-scalar-plain-in"
+      }
+    ]
+  "flow-scalar-double-quoted":
+    name: "string.quoted.double.ansible-advanced"
+    begin: "\""
+    beginCaptures:
+      "0":
+        name: "punctuation.definition.string.begin.ansible-advanced"
+    end: "\""
+    endCaptures:
+      "0":
+        name: "punctuation.definition.string.end.ansible-advanced"
+    patterns: [
+      {
+        name: "constant.character.escape.ansible-advanced"
+        match: "\\\\([0abtnvfre \"/\\\\N_Lp]|x\\d\\d|u\\d{4}|U\\d{8})"
+      }
+      {
+        name: "constant.character.escape.double-quoted.newline.ansible-advanced"
+        match: "\\\\\\n"
+      }
+      {
+        include: "#specials"
+      }
+    ]
+  "flow-scalar-single-quoted":
+    name: "string.quoted.single.ansible-advanced"
+    begin: "'"
+    beginCaptures:
+      "0":
+        name: "punctuation.definition.string.begin.ansible-advanced"
+    end: "'(?!')"
+    endCaptures:
+      "0":
+        name: "punctuation.definition.string.end.ansible-advanced"
+    patterns: [
+      {
+        name: "constant.character.escape.single-quoted.ansible-advanced"
+        match: "''"
+      }
+      {
+        include: "#specials"
+      }
+    ]
+  "flow-scalar-plain-in":
+    patterns: [
+      {
+        include: "#flow-scalar-plain-in-implicit-type"
+      }
+      {
+        name: "string.unquoted.plain.in.ansible-advanced"
+        begin: '''
+          (?x)
+            [^\\s[-?:,\\[\\]{}#&*!|>'"%@`]]
+          | [?:-] [^\\s[\\[\\]{},]]
+        '''
+        end: '''
+          (?x)
+          (?=
+              \\s* $
+            | \\s+ \\#
+            | \\s* : (\\s|$)
+            | \\s* : [\\[\\]{},]
+            | \\s* [\\[\\]{},]
+          )
+        '''
+      }
+    ]
+  "flow-scalar-plain-in-implicit-type":
+    patterns: [
+      {
+        match: '''
+          (?x)
+          (?x:
+              (null|Null|NULL|~)
+            | (y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF)
+            | (
+                (?:
+                    [-+]? 0b [0-1_]+ # (base 2)
+                  | [-+]? 0  [0-7_]+ # (base 8)
+                  | [-+]? (?: 0|[1-9][0-9_]*) # (base 10)
+                  | [-+]? 0x [0-9a-fA-F_]+ # (base 16)
+                  | [-+]? [1-9] [0-9_]* (?: :[0-5]?[0-9])+ # (base 60)
+                )
+              )
+            | (
+                (?x:
+                    [-+]? (?: [0-9] [0-9_]*)? \\. [0-9.]* (?: [eE] [-+] [0-9]+)? # (base 10)
+                  | [-+]? [0-9] [0-9_]* (?: :[0-5]?[0-9])+ \\. [0-9_]* # (base 60)
+                  | [-+]? \\. (?: inf|Inf|INF) # (infinity)
+                  |       \\. (?: nan|NaN|NAN) # (not a number)
+                )
+              )
+            | (
+                (?x:
+                    \\d{4} - \\d{2} - \\d{2}           # (y-m-d)
+                  | \\d{4}                           # (year)
+                    - \\d{1,2}                       # (month)
+                    - \\d{1,2}                       # (day)
+                    (?: [Tt] | [ \\t]+) \\d{1,2}      # (hour)
+                    : \\d{2}                         # (minute)
+                    : \\d{2}                         # (second)
+                    (?: \\.\\d*)?                     # (fraction)
+                    (?:
+                          (?:[ \\t]*) Z
+                        | [-+] \\d{1,2} (?: :\\d{1,2})?
+                    )?                              # (time zone)
+                )
+              )
+            | (=)
+            | (<<)
+          )
+          (?:
+              (?=
+                    \\s* $
+                  | \\s+ \\#
+                  | \\s* : (\\s|$)
+                  | \\s* : [\\[\\]{},]
+                  | \\s* [\\[\\]{},]
+              )
+          )
+        '''
+        captures:
+          "1":
+            name: "constant.language.null.ansible-advanced"
+          "2":
+            name: "constant.language.boolean.ansible-advanced"
+          "3":
+            name: "constant.numeric.integer.ansible-advanced"
+          "4":
+            name: "constant.numeric.float.ansible-advanced"
+          "5":
+            name: "constant.other.timestamp.ansible-advanced"
+          "6":
+            name: "constant.language.value.ansible-advanced"
+          "7":
+            name: "constant.language.merge.ansible-advanced"
+      }
+    ]
+  "flow-scalar-plain-out-implicit-type":
+    patterns: [
+      {
+        match: '''
+          (?x)
+          (?x:
+                (null|Null|NULL|~)
+              | (y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF)
+              | (
+                  (?:
+                        [-+]? 0b [0-1_]+ # (base 2)
+                      | [-+]? 0  [0-7_]+ # (base 8)
+                      | [-+]? (?: 0|[1-9][0-9_]*) # (base 10)
+                      | [-+]? 0x [0-9a-fA-F_]+ # (base 16)
+                      | [-+]? [1-9] [0-9_]* (?: :[0-5]?[0-9])+ # (base 60)
+                  )
+                )
+              | (
+                  (?x:
+                        [-+]? (?: [0-9] [0-9_]*)? \\. [0-9.]* (?: [eE] [-+] [0-9]+)? # (base 10)
+                      | [-+]? [0-9] [0-9_]* (?: :[0-5]?[0-9])+ \\. [0-9_]* # (base 60)
+                      | [-+]? \\. (?: inf|Inf|INF) # (infinity)
+                      |       \\. (?: nan|NaN|NAN) # (not a number)
+                  )
+                )
+              | (
+                  (?x:
+                      \\d{4} - \\d{2} - \\d{2}           # (y-m-d)
+                    | \\d{4}                           # (year)
+                      - \\d{1,2}                       # (month)
+                      - \\d{1,2}                       # (day)
+                      (?: [Tt] | [ \\t]+) \\d{1,2}      # (hour)
+                      : \\d{2}                         # (minute)
+                      : \\d{2}                         # (second)
+                      (?: \\.\\d*)?                     # (fraction)
+                      (?:
+                            (?:[ \\t]*) Z
+                          | [-+] \\d{1,2} (?: :\\d{1,2})?
+                      )?                              # (time zone)
+                  )
+                )
+              | (=)
+              | (<<)
+          )
+          (?x:
+              (?=
+                    \\s* $
+                  | \\s+ \\#
+                  | \\s* : (\\s|$)
+              )
+          )
+        '''
+        captures:
+          "1":
+            name: "constant.language.null.ansible-advanced"
+          "2":
+            name: "constant.language.boolean.ansible-advanced"
+          "3":
+            name: "constant.numeric.integer.ansible-advanced"
+          "4":
+            name: "constant.numeric.float.ansible-advanced"
+          "5":
+            name: "constant.other.timestamp.ansible-advanced"
+          "6":
+            name: "constant.language.value.ansible-advanced"
+          "7":
+            name: "constant.language.merge.ansible-advanced"
+      }
+    ]
+  "flow-value":
+    patterns: [
+      {
+        name: "meta.flow-pair.value.ansible-advanced"
+        begin: "\\G(?![},\\]])"
+        end: "(?=[},\\]])"
+        patterns: [
+          {
+            include: "#flow-node"
+          }
+        ]
+      }
+    ]
+firstLineMatch: "^%YAML( ?1.\\d+)?"
+keyEquivalent: "^~Y"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "language-ansible",
   "version": "0.2.1",
-  "description": "Simple ansible syntax package",
+  "description": "Ansible syntax package",
   "repository": "https://github.com/haad/language-Ansible",
   "license": "MIT",
   "engines": {

--- a/settings/language-ansible.cson
+++ b/settings/language-ansible.cson
@@ -1,3 +1,6 @@
 ".source.ansible":
   editor:
     commentStart: "# "
+".source.ansible-advanced":
+  editor:
+    commentStart: "# "

--- a/tests/test.yaml
+++ b/tests/test.yaml
@@ -50,7 +50,7 @@
       tags:
         - "common"
         - "test"
-      test_var: http://123
+      test_var: "http://toto.com"
       another_war: 31123
       when: True
   tasks:
@@ -76,7 +76,7 @@ test:
     - var: c
 
 openstack_telemetry_internal_url: "http://{{ host }}:{{ port }}"
-openstack_telemetry_public_url: "http://{{ host }}:{{ port }}"
+/* openstack_telemetry_public_url: "http://{{ host }}:{{ port }}" */
 openstack_telemetry_admin_url: "http://{{ host }}:{{ port }}"
 
 ###
@@ -90,7 +90,8 @@ openstack_objectstorage_storage_dir: /srv/node/
 openstack_objectstorage_swift_hash_path_suffix: suffix
 
 vpc_sub_list: [
-  { "cidr": "{{ vpc_sub_public[0].cidr }}", "az": "{{ vpc_sub_public[0].az }}",
+  { cidr: "{{ vpc_sub_public[0].cidr }}", az: "{{ vpc_sub_public[0].az }}",
+    qtretre: "{{ vpc_sub_public[0].az }}",
     "resource_tags": '{ "Environment": "{{ vpc_env }}", "Stack":"{{ stack_name }}", "Tier": "Public", "Name": "{{ vpc_type }}-{{ vpc_env }} public" }' },
   { "cidr": "{{ vpc_sub_public[1].cidr }}", "az": "{{ vpc_sub_public[1].az }}",
     "resource_tags": '{ "Environment": "{{ vpc_env }}", "Stack":"{{ stack_name }}", "Tier": "Public", "Name": "{{ vpc_type }}-{{ vpc_env }} public2" }' },
@@ -103,3 +104,45 @@ vpc_sub_list: [
   { "cidr": "{{ vpc_sub_priv[2].cidr }}", "az": "{{ vpc_sub_priv[2].az }}",
     "resource_tags": '{ "Environment": "{{ vpc_env }}", "Stack":"{{ stack_name }}", "Tier": "Private", "Name": "{{ vpc_type }}-{{ vpc_env }} private3" }'}
 ]
+
+# Conditions supported
+- name: "Test"
+  become: yes
+  become_user: toto
+  register: result
+  when: toto in install_user
+  check_mode: ansible_check_mode
+  changed_when: no
+  failed_when: result | failed and not 'already exists' in result.stdout
+
+- name: "Test"
+  when: >-
+    not result | skipped
+    or result | failed
+  hosts: all
+  become: yes
+
+- name: "Test"
+  when:
+    - toto is defined
+    - 'toto' is defined
+    - "'attention' is present"
+    - '"attention" is present'
+  hosts: all
+  become: yes
+
+# Handle most of the cases with block scalar
+# Workaround insert a blank line
+- name: Let's play
+  vars:
+    content: >-
+      This is a multiline example with some {{ 'jinja' }}
+
+      It support line breaking
+  debug: msg="{{ content }}"
+
+# Limitations of block scalar (indent=0 can be close only by newline following character)
+- name: >-
+    My Play {{ toto }}
+  hosts: all
+  become: yes


### PR DESCRIPTION
Hi,

I have made a new Ansible grammar called ansible-advanced that start from YAML language found on Textmate repository. I have modified it to support   following syntaxes :
-  Jinja syntax when double quoted string or block scalar.
- Highlighting conditionnal ansible keys : changed_when, failed_when, when, check_mode
- Jinja expression inside conditionnal ansible keys

Could you try this syntax and say me what you think of it ?

exemple with test file and my theme :
![ex-syntax](https://user-images.githubusercontent.com/813889/34670401-7a41252a-f476-11e7-99a7-9f4f5ddcdeae.png)
