### PR TITLE
Auto indent when creating YAML lists

### DIFF
--- a/settings/language-ansible.cson
+++ b/settings/language-ansible.cson
@@ -1,6 +1,14 @@
 ".source.ansible":
   editor:
     commentStart: "# "
+    foldEndPattern: "^\\s*$|^\\s*\\}|^\\s*\\]|^\\s*\\)"
+    increaseIndentPattern: '^\\s*.*(:|-) ?(&\\w+)?(\\{[^}"\']*|\\([^)"\']*)?$'
+    decreaseIndentPattern: "^\\s+\\}$"
+    tabType: "soft"
 ".source.ansible-advanced":
   editor:
     commentStart: "# "
+    foldEndPattern: "^\\s*$|^\\s*\\}|^\\s*\\]|^\\s*\\)"
+    increaseIndentPattern: '^\\s*.*(:|-) ?(&\\w+)?(\\{[^}"\']*|\\([^)"\']*)?$'
+    decreaseIndentPattern: "^\\s+\\}$"
+    tabType: "soft"


### PR DESCRIPTION
These are the settings I missed when switching from language-YAML to language-ansible. I've made these changes to my `~/.atom/config.cson` file to match upstream:
https://github.com/atom/language-yaml/blob/784cecc64ffdb891f6a7fbba62e476b0c833e66f/settings/language-yaml.cson

Others should benefit from the defaults as well.